### PR TITLE
perf: support for numba

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,0 +1,41 @@
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from seam_carving import carve
+
+
+class TestRealImage:
+    ROOT = Path(__file__).resolve().parent
+    FIG_DIR = ROOT / "fig"
+    FIG_BEACH = FIG_DIR / "a-strap-black-dress.jpg"
+    FIG_BEACH_GIRL = FIG_DIR / "beach_girl.png"
+    FIG_BEACH_BIRD = FIG_DIR / "beach_bird.png"
+    def setUp(self) -> None:
+        self.img = np.array(Image.open(str(self.FIG_BEACH)))
+        self.mask_girl = np.array(Image.open(str(self.FIG_BEACH_GIRL)).convert("L"))
+        self.mask_bird = np.array(Image.open(str(self.FIG_BEACH_BIRD)).convert("L"))
+    def test_remove_object(self):
+        carve.remove_object(self.img, self.mask_girl)
+        carve.remove_object(self.img, self.mask_bird, self.mask_girl)
+        h, w, _ = self.img.shape
+        with pytest.raises(ValueError):
+            carve.remove_object(np.empty((1, 2, 3, 4)), self.mask_girl)
+        with pytest.raises(ValueError):
+            carve.remove_object(self.img, np.zeros((h, w - 1)))
+        with pytest.raises(ValueError):
+            carve.remove_object(self.img, self.mask_bird, np.zeros((h + 1, w)))
+    def test_protect_object(self):
+        h, w, _ = self.img.shape
+        keep_mask = self.mask_girl | self.mask_bird
+        # carve.resize(self.img, (w + 200, h), "backward", "width-first", keep_mask)
+        print(f"--- Former version")
+        s1 = time.time()
+        carve.resize(self.img, (w + 200, h), "forward", "width-first", None)
+        print(f"Took {time.time() - s1} seconds")
+tri = TestRealImage()
+tri.setUp()
+tri.test_protect_object()

--- a/seam_carving/carve.py
+++ b/seam_carving/carve.py
@@ -1,3 +1,4 @@
+import time
 from typing import Optional, Tuple
 
 import numpy as np
@@ -245,6 +246,7 @@ def _expand_width(src: np.ndarray, delta_width: int, energy_mode: str,
                   keep_mask: Optional[np.ndarray]) -> np.ndarray:
     """Expand the width of image by delta_width pixels"""
     assert src.ndim in (2, 3) and delta_width >= 0
+    start = time.time()
     if src.ndim == 2:
         gray = src
         src_h, src_w = src.shape
@@ -256,6 +258,7 @@ def _expand_width(src: np.ndarray, delta_width: int, energy_mode: str,
 
     seams_mask = _get_seams(gray, delta_width, energy_mode, keep_mask)
     dst = _create_dst(src, src_h, src_w, dst_shape, seams_mask)
+    print(f"Took {time.time()} seconds to insert {delta_width} pixels")
     return dst
 
 

--- a/seam_carving/carve.py
+++ b/seam_carving/carve.py
@@ -258,7 +258,7 @@ def _expand_width(src: np.ndarray, delta_width: int, energy_mode: str,
 
     seams_mask = _get_seams(gray, delta_width, energy_mode, keep_mask)
     dst = _create_dst(src, src_h, src_w, dst_shape, seams_mask)
-    print(f"Took {time.time()} seconds to insert {delta_width} pixels")
+    print(f"Took {time.time() - start} seconds to insert {delta_width} pixels")
     return dst
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
     install_requires=[
         'numpy',
         'scipy',
+        'numba'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
See this PR only as a POC. Maybe you don't want to change the API, but I thought it'd be interesting to share it.

It was actually hard to speed up things since most of the functions are already super fast. But I have found that `_get_forward_seam` could greatly benefit from `numba`, since it can be called a large number of times. The good news is that it does not require that much change to get some speedup #1.

Most edits serve the purpose of making `_get_forward_seam` numba-compatible. The tricky part was that `numpy.min(..., axis=0)` and `numpy.argmin(..., axis=0)` are still not supported by `numba`, and writing such functions, even using `numba` would have been inefficient. 

But, the `choices` array has a small fixed number of rows, so it was possible to implement a function `min_argmin_along_axis_0` that calculates both the minimum and the corresponding indices. In my tests, it is normally faster that `numpy.min` and `numpy.argmin` when compiled just-in-time. Replacing `numpy.min(..., axis=0)` and `numpy.argmin(..., axis=0)` with `min_argmin_along_axis_0` was the key part to make `_get_forward_seam` compatible with `numba`. 

In my tests (e.g: adding 300 seams for a 900x1200 image), it was actually 3 times faster. The more seams are added, the greater the benefit.

N.B: it is only tested for the forward energy, as I only use this. 